### PR TITLE
Add parameter to configure MQTT base topic level

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docker-publish:
-    name: Publish to Docker Hub
+    name: Publish to GHCR
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
           tags: |
-            ghcr.io/${{ env.GITHUB_REPOSITORY }}::latest
-            ghcr.io/${{ env.GITHUB_REPOSITORY }}:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
           labels: "version=${{ steps.version.outputs.version }}"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,14 +37,16 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1.12.0
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2.7.0
         with:
           push: true
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
           tags: |
-            dchesterton/snmp2mqtt:latest
-            dchesterton/snmp2mqtt:${{ steps.version.outputs.version }}
+            ghcr.io/${{ env.GITHUB_REPOSITORY }}::latest
+            ghcr.io/${{ env.GITHUB_REPOSITORY }}:${{ steps.version.outputs.version }}
           labels: "version=${{ steps.version.outputs.version }}"
+

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ mqtt:
     cert: /cert/cert.pem # Optional: certificate for TLS connection (default: none)
     key: /cert/key.pem # Optional: private key for TLS connection (default: none)
     reject_unauthorized: true # Optional: if not false, the server certificate is verified against the list of supplied CAs. Override with caution (default: true when using TLS)
+    base_topic: # Optional: the base level of the topic (default snmp2mqtt)
 
 homeassistant:
     discovery: true # Optional: enable Home Assistant discovery (default: false)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ mqtt:
     cert: /cert/cert.pem # Optional: certificate for TLS connection (default: none)
     key: /cert/key.pem # Optional: private key for TLS connection (default: none)
     reject_unauthorized: true # Optional: if not false, the server certificate is verified against the list of supplied CAs. Override with caution (default: true when using TLS)
-    name_as_topic: true # Optional: Use the target's name as the MQTT topic instead of the host (default: false)
+    target_name_as_topic: true # Optional: Use the target's name as the MQTT topic instead of the host (default: false)
 
 homeassistant:
     discovery: true # Optional: enable Home Assistant discovery (default: false)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ mqtt:
     cert: /cert/cert.pem # Optional: certificate for TLS connection (default: none)
     key: /cert/key.pem # Optional: private key for TLS connection (default: none)
     reject_unauthorized: true # Optional: if not false, the server certificate is verified against the list of supplied CAs. Override with caution (default: true when using TLS)
-    base_topic: # Optional: the base level of the topic (default snmp2mqtt)
+    base_topic: # Optional: the base level of the topic (default: snmp2mqtt)
 
 homeassistant:
     discovery: true # Optional: enable Home Assistant discovery (default: false)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ mqtt:
     cert: /cert/cert.pem # Optional: certificate for TLS connection (default: none)
     key: /cert/key.pem # Optional: private key for TLS connection (default: none)
     reject_unauthorized: true # Optional: if not false, the server certificate is verified against the list of supplied CAs. Override with caution (default: true when using TLS)
+    name_as_topic: true # Optional: Use the target's name as the MQTT topic instead of the host (default: false)
 
 homeassistant:
     discovery: true # Optional: enable Home Assistant discovery (default: false)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "snmp2mqtt",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "license": "MIT",
     "bin": {
         "snmp2mqtt": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "snmp2mqtt",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "license": "MIT",
     "bin": {
         "snmp2mqtt": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "snmp2mqtt",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "license": "MIT",
     "bin": {
         "snmp2mqtt": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "snmp2mqtt",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "license": "MIT",
     "bin": {
         "snmp2mqtt": "dist/index.js"

--- a/src/config_schema.ts
+++ b/src/config_schema.ts
@@ -148,6 +148,10 @@ export const schema = {
                     type: "boolean",
                     default: true,
                 },
+                target_name_as_topic: {
+                    type: "boolean",
+                    default: false,
+                },
             },
             additionalProperties: false,
         },

--- a/src/config_schema.ts
+++ b/src/config_schema.ts
@@ -148,6 +148,10 @@ export const schema = {
                     type: "boolean",
                     default: true,
                 },
+                base_topic: {
+                    type: "string",
+                    default: "snmp2mqtt",
+                },
             },
             additionalProperties: false,
         },

--- a/src/mqtt.ts
+++ b/src/mqtt.ts
@@ -110,9 +110,9 @@ export const createClient = async (
     return {
         publish,
         sensorStatusTopic: (sensor: SensorConfig, target: TargetConfig) =>
-            `snmp2mqtt/${target.host}/${slugify(sensor.name)}/status`,
+            `${config.base_topic}/${target.host}/${slugify(sensor.name)}/status`,
         sensorValueTopic: (sensor: SensorConfig, target: TargetConfig) =>
-            `snmp2mqtt/${target.host}/${slugify(sensor.name)}/value`,
+            `${config.base_topic}/${target.host}/${slugify(sensor.name)}/value`,
         STATUS_TOPIC,
         ONLINE,
         OFFLINE,

--- a/src/mqtt.ts
+++ b/src/mqtt.ts
@@ -110,9 +110,9 @@ export const createClient = async (
     return {
         publish,
         sensorStatusTopic: (sensor: SensorConfig, target: TargetConfig) =>
-            `snmp2mqtt/${target.host}/${slugify(sensor.name)}/status`,
+            `snmp2mqtt/${config.target_name_as_topic && target.name ? slugify(target.name) : target.host}/${slugify(sensor.name)}/status`,
         sensorValueTopic: (sensor: SensorConfig, target: TargetConfig) =>
-            `snmp2mqtt/${target.host}/${slugify(sensor.name)}/value`,
+            `snmp2mqtt/${config.target_name_as_topic && target.name ? slugify(target.name) : target.host}/${slugify(sensor.name)}/value`,
         STATUS_TOPIC,
         ONLINE,
         OFFLINE,

--- a/src/mqtt.ts
+++ b/src/mqtt.ts
@@ -8,8 +8,8 @@ import { EventEmitter } from "events";
 const OFFLINE = "offline";
 const ONLINE = "online";
 
-const STATUS_TOPIC = "snmp2mqtt/status";
-const CONFIG_TOPIC = "snmp2mqtt/config";
+const STATUS_TOPIC = "status";
+const CONFIG_TOPIC = "config";
 
 const connect = (config: MQTTConfig) => {
     const port = config.port ? config.port : config.ca ? 8883 : 1883;
@@ -19,7 +19,7 @@ const connect = (config: MQTTConfig) => {
         protocol: "mqtt",
         port,
         will: {
-            topic: STATUS_TOPIC,
+            topic: `${config.base_topic}/${STATUS_TOPIC}`,
             payload: OFFLINE,
             retain: config.retain,
             qos: config.qos,
@@ -31,6 +31,7 @@ const connect = (config: MQTTConfig) => {
         rejectUnauthorized: config.reject_unauthorized,
     };
 
+    console.log(`${config.base_topic}/${STATUS_TOPIC}`);
     console.log(config);
 
     if (config.username) {
@@ -94,8 +95,8 @@ export const createClient = async (
     };
 
     const onConnect = async () => {
-        await publish(STATUS_TOPIC, ONLINE);
-        await publish(CONFIG_TOPIC, { version });
+        await publish(`${config.base_topic}/${STATUS_TOPIC}`, ONLINE);
+        await publish(`${config.base_topic}/${CONFIG_TOPIC}`, { version });
         emitter.emit("connect");
     };
 
@@ -113,7 +114,7 @@ export const createClient = async (
             `${config.base_topic}/${target.host}/${slugify(sensor.name)}/status`,
         sensorValueTopic: (sensor: SensorConfig, target: TargetConfig) =>
             `${config.base_topic}/${target.host}/${slugify(sensor.name)}/value`,
-        STATUS_TOPIC,
+        STATUS_TOPIC: '`${config.base_topic}/${STATUS_TOPIC}`',
         ONLINE,
         OFFLINE,
         on: (event: "close" | "connect", cb: () => void) =>
@@ -121,7 +122,7 @@ export const createClient = async (
         off: (event: "close" | "connect", cb: () => void) =>
             emitter.off(event, cb),
         end: async () => {
-            await client.publish(STATUS_TOPIC, OFFLINE);
+            await client.publish(`${config.base_topic}/${STATUS_TOPIC}`, OFFLINE);
             await client.end();
         },
         qos: config.qos,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface MQTTConfig {
     key?: string;
     clean: boolean;
     reject_unauthorized?: boolean;
+    base_topic?: string;
 }
 
 export interface TargetConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface MQTTConfig {
     key?: string;
     clean: boolean;
     reject_unauthorized?: boolean;
+    target_name_as_topic?: boolean;
 }
 
 export interface TargetConfig {


### PR DESCRIPTION
## Intent

Adds a configuration parameter to set the MQTT base topic level

## Example

```yaml
mqtt:
  # < snip >
  base_topic: snmp
```

### Effect

* before setting `base_topic`: messages are published to `snmp2mqtt/...`
* after setting `base_topic`: messages are published to `snmp/...` 

<img width="291" alt="image" src="https://user-images.githubusercontent.com/1703560/204103265-4453fd10-0f7d-49b7-9398-1f8db3ffed41.png">
