### PR TITLE
First stab at fixing MQTT topic paths for HA discovery in 2023.8+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist
 node_modules
 config.yml
 yarn-error.log
+
+# JetBrains Cruft
+/.idea/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,2 @@
+include:
+  - template: Docker.gitlab-ci.yml

--- a/src/home_assistant.ts
+++ b/src/home_assistant.ts
@@ -1,6 +1,6 @@
 import { Client } from "./mqtt";
 import { TargetConfig } from "./types";
-import { md5, slugify } from "./util";
+import {md5, nodify, slugify} from "./util";
 
 export const createHomeAssistantTopics = async (
     mqtt: Client,
@@ -31,7 +31,8 @@ export const createHomeAssistantTopics = async (
                 ? "binary_sensor"
                 : "sensor";
             const sensorName = slugify(sensor.name);
-            const topic = `${prefix}/${sensorType}/snmp2mqtt/${sensorName}/config`;
+            const nodeName = nodify(target.host);
+            const topic = `${prefix}/${sensorType}/snmp2mqtt-${nodeName}/${sensorName}/config`;
 
             const discovery: any = {
                 availability: [

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,4 +11,8 @@ export function slugify(str: string) {
     ).replace(/^_+|_+$/g, "");
 }
 
+export function nodify(str: string) {
+    return str.replaceAll(/[^a-zA-Z0-9_-]/g, '_')
+}
+
 export const md5 = (str: string) => createHash("md5").update(str).digest("hex");


### PR DESCRIPTION
HomeAssistant 2023.8 changed the naming requirements for MQTT entities - entity names can no longer contain the device name. This means multiple entities might have the same name if you have multiple instances of the same device type, and they will clobber each other with the existing discovery topic naming scheme. This change inserts the host into the discovery topic name to avoid the clobbering.